### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -201,4 +201,8 @@ def is_valid_chrome_store_url(url: str) -> bool:
     if not validate_url(url):
         return False
 
-    return "/detail/" in url and "chromewebstore.google.com" in url
+    parsed = urllib.parse.urlparse(url)
+    return (
+        parsed.hostname == "chromewebstore.google.com"
+        and "/detail/" in parsed.path
+    )


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/Chrome-Web-Store-Lister/security/code-scanning/1](https://github.com/xixu-me/Chrome-Web-Store-Lister/security/code-scanning/1)

To fix the problem, the code should parse the URL using `urllib.parse.urlparse` and check the `hostname` property, rather than searching for a substring. The check should ensure that the hostname is exactly `chromewebstore.google.com` or, if subdomains are allowed, ends with `.chromewebstore.google.com`. In this context, only the main domain should be accepted. The fix should be applied in the `is_valid_chrome_store_url` function in `src/utils.py`, replacing the substring check with a proper hostname check. No new methods are needed, but the function should use `urllib.parse.urlparse` (already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
